### PR TITLE
Require code formatting with Python Black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore =
+    E203,  # Python Black puts whitespace around ':'.

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -21,6 +21,9 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 . --count --statistics --config=.flake8
+    - name: Check code formatting with black
+      run: |
+        black --check ./
     - name: Test with pytest
       run: |
         pytest

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ my_library
 
 ## Citation key style
 
-`zoia` generates citekeys by taking the last names of the first three authors
-on the paper and joining them by `+`, (with a trailing `+` if there are more
-than three authors), followed by the last two digits of the publication year,
+`zoia`'s citation key style is based on [Harvard
+referencing](https://en.wikipedia.org/wiki/Parenthetical_referencing).  `zoia`
+generates citekeys by taking the last names of the first three authors on the
+paper and joining them by `+`, (with a trailing `+` if there are more than
+three authors), followed by the last two digits of the publication year,
 followed by a hyphen, followed by the first word of the title (excluding common
 words like "the", "a", "on", etc.).  
 
@@ -48,7 +50,6 @@ words like "the", "a", "on", etc.).
 | --------                                  | -----                                                                          | ---- | ------------                  |
 | Einstein, A.                              | On the electrodynamics of moving bodies                                        | 1905 | einstein05-electrodynamics    |
 | Einstein, A., and Rosen, N.               | The particle problem in the general theory of relativity                       | 1935 | einstein+rosen35-particle     |
-| Einstein, A., Podolsky, B., and Rosen, N. | Can quantum-mechanical description of physical reality be considered complete? | 1935 | einstein+podolsky+rosen35-can |
 | Abbott, B. P., et al.                     | Observation of Gravitational Waves from a Binary Black Hole Merger             | 2016 | abbott+16-obseravtion         |
 
 ### Collisions
@@ -56,14 +57,13 @@ words like "the", "a", "on", etc.).
 Inevitably you will one day try to add two different papers which have the same
 auto-generated citation keys.  The default style makes this rare, but does not
 guarantee that it will never happen.  When it does, `zoia` will add the
-character `b` after the year.  For example, suppose a less well known physicist
-named Egbert Einstein had written another, somewhat less revolutionary, paper
-in 1905 called "On the electrodynamics of stationary bodies" and you tried to
-add it, it would get a citekey of `einstein05b-electrodynamics`.  If the
-citekey with the `b` already exists, `zoia` will try adding a `c`, and then a
-`d`, etc. all the way up to `z`.  If that's still not good enough it will
-continue with `aa`, `ab`, etc., though for your sake pray that things never
-come to that.
+character `b` after the year.  For example, suppose a lesser known physicist by
+the name of Egbert Einstein had written another, somewhat less revolutionary,
+paper in 1905 called "On the electrodynamics of stationary bodies".  If you
+tried to add it, it would get a citekey of `einstein05b-electrodynamics`.  If
+the citekey with the `b` already exists, `zoia` will try adding a `c`, and then
+a `d`, etc. all the way up to `z`.  If that's still not good enough it will
+continue with `aa`, `ab`, etc., though pray that things never come to that.
 
 Note that the first paper will retain its original citekey --- it won't get an
 `a` added to it.  This is because you may have been using that old citekey in
@@ -115,7 +115,7 @@ ISBN, and PDFs directly.
 
 You can open the PDF of a paper in your library from its citekey by running:
 
-```sh
+```
 zoia open <citekey>
 ```
 
@@ -131,6 +131,15 @@ running:
 ```
 zoia note <citekey>
 ```
+
+## Synchronization
+
+Although `zoia` does not natively support synchronization across multiple
+devices at the moment, its simple data structure makes it easy to use with
+third-party synchronization software.  In particular I recommend using
+[Syncthing](https://syncthing.net/) for this purpose.  By pointing Syncthing at
+the directory containing `zoia`'s library on both devices you can keep your
+library synchronized.
 
 ## About the name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,11 @@
+[tool.black]
+line-length = 79
+skip-string-normalization = true
+target-version = ['py38']
+include = '''(
+    zoia
+  | tests
+).*\.pyi?$'''
+
 [tool.pytest.ini_options]
 timeout = 5

--- a/zoia/ids/arxiv.py
+++ b/zoia/ids/arxiv.py
@@ -71,18 +71,17 @@ def is_valid_arxiv_id(identifier):
 
     identifier = normalize(identifier)
     if identifier.lower().startswith('arxiv:'):
-        identifier = identifier[len('arxiv:'):]
+        identifier = identifier[len('arxiv:') :]
 
-    return (
-        _is_valid_old_style_arxiv_id(identifier) or
-        _is_valid_new_style_arxiv_id(identifier)
-    )
+    return _is_valid_old_style_arxiv_id(
+        identifier
+    ) or _is_valid_new_style_arxiv_id(identifier)
 
 
 def normalize(identifier):
     """Remove the initial 'arxiv:' if it exists."""
 
     if identifier.lower().startswith('arxiv:'):
-        identifier = identifier[len('arxiv:'):]
+        identifier = identifier[len('arxiv:') :]
 
     return identifier

--- a/zoia/init.py
+++ b/zoia/init.py
@@ -79,5 +79,5 @@ def init(directory):
 
     click.secho(
         f'Your zoia library was successfully initialized at {directory}!',
-        fg='blue'
+        fg='blue',
     )

--- a/zoia/normalization.py
+++ b/zoia/normalization.py
@@ -7,7 +7,8 @@ def strip_diacritics(s):
     """Remove diacritics from the string."""
     return ''.join(
         [
-            char for char in unicodedata.normalize('NFD', s)
+            char
+            for char in unicodedata.normalize('NFD', s)
             if unicodedata.category(char) != 'Mn'
         ]
     )
@@ -33,5 +34,5 @@ def split_name(name):
             else:
                 last_names.append(elem)
     last_name = ' '.join(reversed(last_names))
-    first_name = ' '.join(names[:len(names) - len(last_names)])
+    first_name = ' '.join(names[: len(names) - len(last_names)])
     return [first_name, last_name]


### PR DESCRIPTION
This PR does the following:

* Adds some settings for Python Black
* Applies Python Black to the codebase
* Adds a CI check to make sure that Black approves of the code formatting.
* Modifies the linter rules to be consistent with Black.